### PR TITLE
Adding BMI semantics

### DIFF
--- a/src/main/java/dev/ikm/tinkar/sandbox/BMIConcept.java
+++ b/src/main/java/dev/ikm/tinkar/sandbox/BMIConcept.java
@@ -1,0 +1,29 @@
+package dev.ikm.tinkar.sandbox;
+
+import dev.ikm.tinkar.common.util.uuid.UuidUtil;
+import dev.ikm.tinkar.terms.EntityProxy;
+
+public class BMIConcept {
+    private String snomedctId;
+    private String decription;
+
+    public String getSnomedctId() {
+        return snomedctId;
+    }
+
+    public String getDecription() {
+        return decription;
+    }
+
+    public BMIConcept(String snomedctId, String decription) {
+        this.snomedctId = snomedctId;
+        this.decription = decription;
+    }
+
+    public EntityProxy.Concept makeConcept(){
+        return  EntityProxy.Concept.make(this.decription, UuidUtil.fromSNOMED(this.snomedctId));
+    }
+
+
+
+}


### PR DESCRIPTION
I need help (maybe from Andrew) to get this function to work:
private static void createBMISematic(StarterData starterData,
                                         Concept bmiConcept, Concept cdcField1, Concept greaterThanConceptField2,
                                         float referenceRangeMinimum, float referenceRangeMaximum, String exampleUUCM) {

        MutableList<Object> classPatternFields = Lists.mutable.empty();
        classPatternFields.add(cdcField1.nid());
        classPatternFields.add(greaterThanConceptField2.nid());
        classPatternFields.add(referenceRangeMinimum);
        classPatternFields.add(TinkarTerm.LESS_THAN.nid());
        classPatternFields.add(referenceRangeMaximum);
        classPatternFields.add(exampleUUCM);

        UUIDUtility uuidUtility = new UUIDUtility();
        PublicId patternPublicId = PublicIds.of(uuidUtility.createUUID("Value Constraint Pattern"));
        int patternNid = EntityService.get().nidForPublicId(patternPublicId);
        PublicId referencedComponentPublicID = bmiConcept.publicId();
        int referencedComponentNid = EntityService.get().nidForPublicId(referencedComponentPublicID);
        PublicId semantic = PublicIds.singleSemanticId(patternPublicId, referencedComponentPublicID);
        int semanticNid = EntityService.get().nidForPublicId(semantic);
        UUID primordialUUID = semantic.asUuidArray()[0];
        int stampNid = EntityService.get().nidForPublicId(starterData.getAuthoringSTAMP());

        writeSemantic(semanticNid, primordialUUID, patternNid, referencedComponentNid, stampNid, classPatternFields);private static void createBMISematic(StarterData starterData,
                                         Concept bmiConcept, Concept cdcField1, Concept greaterThanConceptField2,
                                         float referenceRangeMinimum, float referenceRangeMaximum, String exampleUUCM) {

        MutableList<Object> classPatternFields = Lists.mutable.empty();
        classPatternFields.add(cdcField1.nid());
        classPatternFields.add(greaterThanConceptField2.nid());
        classPatternFields.add(referenceRangeMinimum);
        classPatternFields.add(TinkarTerm.LESS_THAN.nid());
        classPatternFields.add(referenceRangeMaximum);
        classPatternFields.add(exampleUUCM);

        UUIDUtility uuidUtility = new UUIDUtility();
        PublicId patternPublicId = PublicIds.of(uuidUtility.createUUID("Value Constraint Pattern"));
        int patternNid = EntityService.get().nidForPublicId(patternPublicId);
        PublicId referencedComponentPublicID = bmiConcept.publicId();
        int referencedComponentNid = EntityService.get().nidForPublicId(referencedComponentPublicID);
        PublicId semantic = PublicIds.singleSemanticId(patternPublicId, referencedComponentPublicID);
        int semanticNid = EntityService.get().nidForPublicId(semantic);
        UUID primordialUUID = semantic.asUuidArray()[0];
        int stampNid = EntityService.get().nidForPublicId(starterData.getAuthoringSTAMP());

        writeSemantic(semanticNid, primordialUUID, patternNid, referencedComponentNid, stampNid, classPatternFields);